### PR TITLE
Bug fix: io.Readers should return first available data

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -26,7 +26,7 @@ func Wrap(conn net.Conn, head []byte) *Conn {
 func (conn *Conn) Read(b []byte) (int, error) {
 	n := copy(b, conn.head)
 	conn.head = conn.head[n:]
-	if n == len(b) {
+	if n > 0 {
 		return n, nil
 	}
 	n1, e := conn.Conn.Read(b[n:])

--- a/conn_test.go
+++ b/conn_test.go
@@ -62,6 +62,10 @@ func TestPreConn(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.Equal(t, n, len(b), "Read() should return as many data as possible")
+	assert.Equal(t, head, string(b[:n]), "Read() should return first available data")
+	n, err = pconn.Read(b[n:])
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, full, string(b))
 }


### PR DESCRIPTION
Not a bug per se as this behavior is convention and not mandated. Still, it is
better that we follow convention.

For more info, see: https://golang.org/pkg/io/#Reader