### PR TITLE
Add concurrency safety

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -2,14 +2,13 @@ package preconn
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io"
 	"net"
-	"sync"
 	"testing"
 
+	"github.com/getlantern/nettest"
+
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -73,32 +72,14 @@ func TestPreConn(t *testing.T) {
 	assert.Equal(t, full, string(b))
 }
 
-// The intent of this test is to expose data races. Run with -race.
-func TestConcurrentReads(t *testing.T) {
-	const parallelism = 10
-
-	a, b := net.Pipe()
-	a = Wrap(a, []byte("hello from c2"))
-	defer a.Close()
-	defer b.Close()
-
-	go io.Copy(b, rand.Reader)
-
-	wg := new(sync.WaitGroup)
-	errs := make(chan error, parallelism)
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			buf := make([]byte, 1024)
-			_, err := a.Read(buf)
-			errs <- err
-		}()
-	}
-	wg.Wait()
-	close(errs)
-
-	for err := range errs {
-		require.NoError(t, err)
-	}
+// Use nettest to detect any data races.
+func TestWithNetTest(t *testing.T) {
+	nettest.TestConn(t, func() (net.Conn, net.Conn, func(), error) {
+		c1, c2 := net.Pipe()
+		stop := func() {
+			c1.Close()
+			c2.Close()
+		}
+		return Wrap(c1, []byte{}), c2, stop, nil
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/getlantern/preconn
+
+go 1.16
+
+require (
+	github.com/getlantern/nettest v1.0.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/getlantern/nettest v1.0.0 h1:xg8vq9JrGzrFGFkFGwZwIJ5+kwtvyqNDIADwrANvhQg=
+github.com/getlantern/nettest v1.0.0/go.mod h1:8wY0QwrdpkayCBQXjhZoJuwu2IHfp4UErrxgwaJ2UM4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
In working on https://github.com/getlantern/tlsmasq/issues/20, I was running into data races rooted in this library.  It's a pretty easy and low-impact fix.

I benchmarked this change as follows:
```
func BenchmarkRead(b *testing.B) {
	const bufSize = 1024

	c1, c2 := net.Pipe()
	c1 = Wrap(c1, []byte("hello from c2"))

	data := make([]byte, bufSize*b.N)
	if _, err := rand.Reader.Read(data); err != nil {
		b.Fatalf("failed to prepare data: %v", err)
	}

	buf := make([]byte, bufSize)
	go io.Copy(c2, bytes.NewReader(data))

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		c1.Read(buf)
	}
}
```

On this branch, this produces:
```
goos: darwin
goarch: amd64
pkg: github.com/getlantern/preconn
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkRead-12    	  964540	      1118 ns/op
PASS
ok  	github.com/getlantern/preconn	3.574s
```

On master, this produces:
```
goos: darwin
goarch: amd64
pkg: github.com/getlantern/preconn
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkRead-12    	 1000000	      1088 ns/op
PASS
ok  	github.com/getlantern/preconn	3.284s
```

So, these changes constitute a slowdown of ~30 ns per operation, a difference of about 3%.